### PR TITLE
Disable Host check for devServer

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -11,6 +11,7 @@ const config = merge(CommonConfig, {
   devServer: {
     publicPath: path.resolve(__dirname, '/'),
     // Server can be visible also by your IP address in LAN
+    disableHostCheck: true,
     host: '0.0.0.0',
     port: 3000,
     hot: true,


### PR DESCRIPTION
Added `disableHostCheck: true` for `devServer` to allow VM and containerized development.